### PR TITLE
feat: v2.2 API surface — RetrieveTrace + ProcessFromUrl (7.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [7.1.0]
+
+* Added `RetrieveTrace(id)` — retrieves the processing event trace for a previously scanned file (`GET /v2.2/files/{id}/trace`); returns `null` on 404. Preview surface per the v2.2 API spec.
+* Added `ProcessFromUrl(location, callback?, metadata?)` — synchronous scan of a remote URL (`POST /v2.2/files` with `location` form field). Preview surface per the v2.2 API spec.
+
 ## 7.0.0
 
 * **Breaking:** NuGet package renamed from `UvaSoftware.Scanii` to `Scanii`. Install: `dotnet add package Scanii`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```
-dotnet add package Scanii --version 7.0.0
+dotnet add package Scanii --version 7.1.0
 ```
 
 ## SDK Principles
@@ -37,8 +37,10 @@ All methods are on `IScaniiClient`, created via `ScaniiClients.CreateDefault`.
 |---|---|
 | `Process(path/stream, callback?, metadata?)` | Synchronous file scan |
 | `ProcessAsync(path/stream, callback?, metadata?)` | Server-side async scan, returns pending result |
+| `ProcessFromUrl(url, callback?, metadata?)` | Synchronous scan of a remote URL (v2.2 preview) |
 | `Fetch(url, callback?, metadata?)` | Server-side fetch-and-scan of a remote URL |
 | `Retrieve(id)` | Retrieve a previous scan result |
+| `RetrieveTrace(id)` | Retrieve processing event trace; returns `null` on 404 (v2.2 preview) |
 | `CreateAuthToken(timeoutSeconds)` | Mint a short-lived auth token |
 | `RetrieveAuthToken(id)` | Inspect an auth token |
 | `DeleteAuthToken(id)` | Revoke an auth token |

--- a/Scanii.Tests/ScaniiClientTests.cs
+++ b/Scanii.Tests/ScaniiClientTests.cs
@@ -198,7 +198,7 @@ namespace Scanii.Tests
     {
       var r = await _client.Fetch(
         "https://scanii.s3.amazonaws.com/eicarcom2.zip",
-        metadata: new Dictionary<string, string> {{"hello", "world"}});
+        metadata: new Dictionary<string, string> { { "hello", "world" } });
 
       Assert.That(r.ResourceId, Is.Not.Null);
 
@@ -216,6 +216,38 @@ namespace Scanii.Tests
 
       Assert.ThrowsAsync<ScaniiAuthException>(async () =>
         await badClient.Process(_cleanFile));
+    }
+
+    [Test]
+    public async Task ShouldRetrieveTraceForKnownId()
+    {
+      var processed = await _client.Process(_cleanFile);
+      var trace = await _client.RetrieveTrace(processed.ResourceId);
+
+      Assert.That(trace, Is.Not.Null);
+      Assert.That(trace.Events, Is.Not.Empty);
+      foreach (var ev in trace.Events)
+      {
+        Assert.That(ev.Timestamp, Is.Not.EqualTo(default(DateTime)));
+        Assert.That(ev.Message, Is.Not.Null);
+      }
+    }
+
+    [Test]
+    public async Task ShouldReturnNullForUnknownTraceId()
+    {
+      var result = await _client.RetrieveTrace("does-not-exist-00000000");
+      Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public async Task ShouldProcessFromUrl()
+    {
+      var r = await _client.ProcessFromUrl($"{Endpoint}/static/eicar.txt");
+
+      Assert.That(r, Is.Not.Null);
+      Assert.That(r.ResourceId, Is.Not.Null);
+      Assert.That(r.Findings, Contains.Item("content.malicious.eicar-test-signature"));
     }
 
     /// <summary>

--- a/Scanii/IScaniiClient.cs
+++ b/Scanii/IScaniiClient.cs
@@ -104,5 +104,26 @@ namespace Scanii
     /// <returns>the auth token</returns>
     /// <exception cref="ScaniiException"></exception>
     Task<ScaniiAuthToken> RetrieveAuthToken(string id);
+
+    /// <summary>
+    ///   Retrieves the processing event trace for a previously scanned file (https://scanii.github.io/openapi/v22/).
+    ///   This is preview surface in the v2.2 API — behavior may change in future releases.
+    /// </summary>
+    /// <param name="id">id of the previously scanned content</param>
+    /// <returns>trace result, or null if the id is not found (404)</returns>
+    /// <exception cref="ScaniiException"></exception>
+    Task<ScaniiTraceResult> RetrieveTrace(string id);
+
+    /// <summary>
+    ///   Submits a remote URL for synchronous processing (https://scanii.github.io/openapi/v22/).
+    ///   This is preview surface in the v2.2 API — behavior may change in future releases.
+    /// </summary>
+    /// <param name="location">URL of the content to be processed</param>
+    /// <param name="callback">optional location (URL) to be notified and receive the result</param>
+    /// <param name="metadata">optional metadata to be added to this analysis</param>
+    /// <returns>processing result</returns>
+    /// <exception cref="ScaniiException"></exception>
+    Task<ScaniiProcessingResult> ProcessFromUrl(string location, string callback = null,
+      Dictionary<string, string> metadata = null);
   }
 }

--- a/Scanii/Internal/DefaultScaniiClient.cs
+++ b/Scanii/Internal/DefaultScaniiClient.cs
@@ -29,7 +29,7 @@ namespace Scanii.Internal
     public async Task<ScaniiProcessingResult> Process(Stream contents, string callback = null,
       Dictionary<string, string> metadata = null)
     {
-      var formDataContent = new MultipartFormDataContent {{new StreamContent(contents), "file"}};
+      var formDataContent = new MultipartFormDataContent { { new StreamContent(contents), "file" } };
 
       if (metadata != null)
         foreach (var keyValuePair in metadata)
@@ -61,7 +61,7 @@ namespace Scanii.Internal
     public async Task<ScaniiPendingResult> ProcessAsync(Stream contents, string callback = null,
       Dictionary<string, string> metadata = null)
     {
-      var req = new MultipartFormDataContent {{new StreamContent(contents), "file"}};
+      var req = new MultipartFormDataContent { { new StreamContent(contents), "file" } };
 
       if (metadata != null)
         foreach (var keyValuePair in metadata)
@@ -125,7 +125,7 @@ namespace Scanii.Internal
     {
       if (location == null) throw new ArgumentNullException(nameof(location));
 
-      var parameters = new Dictionary<string, string> {{"location", location}};
+      var parameters = new Dictionary<string, string> { { "location", location } };
 
       if (callback != null) parameters.Add("callback", callback);
 
@@ -150,7 +150,7 @@ namespace Scanii.Internal
 
     public async Task<ScaniiAuthToken> CreateAuthToken(int timeoutInSeconds = 300)
     {
-      var parameters = new Dictionary<string, string> {{"timeout", timeoutInSeconds.ToString()}};
+      var parameters = new Dictionary<string, string> { { "timeout", timeoutInSeconds.ToString() } };
 
       var req = new FormUrlEncodedContent(parameters);
       using var response = await _httpClient.PostAsync("/v2.2/auth/tokens", req);
@@ -196,6 +196,55 @@ namespace Scanii.Internal
       return DecorateEntity(
         await JsonSerializer.DeserializeAsync<ScaniiAuthToken>(await response.Content.ReadAsStreamAsync()),
         response);
+    }
+
+    public async Task<ScaniiTraceResult> RetrieveTrace(string id)
+    {
+      using var response = await _httpClient.GetAsync($"/v2.2/files/{id}/trace");
+      Trace.WriteLine($"[scanii] GET /v2.2/files/{id}/trace status={response.StatusCode}");
+
+      if (response.StatusCode == HttpStatusCode.NotFound) return null;
+
+      CheckForErrors(response);
+
+      if (response.StatusCode != HttpStatusCode.OK)
+      {
+        var responseBody = await response.Content.ReadAsStringAsync();
+        throw new ScaniiException(
+          $"Invalid HTTP response from service, code: {response.StatusCode} message: {responseBody}");
+      }
+
+      return DecorateEntity(
+        await JsonSerializer.DeserializeAsync<ScaniiTraceResult>(await response.Content.ReadAsStreamAsync()),
+        response);
+    }
+
+    public async Task<ScaniiProcessingResult> ProcessFromUrl(string location, string callback = null,
+      Dictionary<string, string> metadata = null)
+    {
+      if (location == null) throw new ArgumentNullException(nameof(location));
+
+      var formDataContent = new MultipartFormDataContent { { new StringContent(location), "location" } };
+
+      if (callback != null) formDataContent.Add(new StringContent(callback), "callback");
+
+      if (metadata != null)
+        foreach (var keyValuePair in metadata)
+          formDataContent.Add(new StringContent(keyValuePair.Value), $"metadata[{keyValuePair.Key}]");
+
+      using var response = await _httpClient.PostAsync("/v2.2/files", formDataContent);
+      Trace.WriteLine($"[scanii] POST /v2.2/files (from-url) status={response.StatusCode}");
+
+      CheckForErrors(response);
+
+      if (response.StatusCode == HttpStatusCode.Created)
+        return DecorateEntity(
+          await JsonSerializer.DeserializeAsync<ScaniiProcessingResult>(await response.Content.ReadAsStreamAsync()),
+          response);
+
+      var responseBody = await response.Content.ReadAsStringAsync();
+      throw new ScaniiException(
+        $"Invalid HTTP response from service, code: {response.StatusCode} message: {responseBody}");
     }
 
     private static void CheckForErrors(HttpResponseMessage response)

--- a/Scanii/Models/ScaniiResult.cs
+++ b/Scanii/Models/ScaniiResult.cs
@@ -1,4 +1,4 @@
-﻿namespace Scanii.Models
+namespace Scanii.Models
 {
   public class ScaniiResult
   {

--- a/Scanii/Models/ScaniiTraceEvent.cs
+++ b/Scanii/Models/ScaniiTraceEvent.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace Scanii.Models
+{
+  public class ScaniiTraceEvent
+  {
+    [JsonPropertyName("timestamp")] public DateTime Timestamp { get; set; }
+    [JsonPropertyName("message")] public string Message { get; set; }
+  }
+}

--- a/Scanii/Models/ScaniiTraceResult.cs
+++ b/Scanii/Models/ScaniiTraceResult.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Scanii.Models
+{
+  public class ScaniiTraceResult : ScaniiResult
+  {
+    [JsonPropertyName("id")] public string ResourceId { get; set; }
+    [JsonPropertyName("events")] public List<ScaniiTraceEvent> Events { get; set; } = new List<ScaniiTraceEvent>();
+  }
+}

--- a/Scanii/Scanii.csproj
+++ b/Scanii/Scanii.csproj
@@ -7,7 +7,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
 
     <!--always rev this up-->
-    <Version>7.0.0</Version>
+    <Version>7.1.0</Version>
 
     <LangVersion>8</LangVersion>
     <Company>Uva Software, LLC</Company>


### PR DESCRIPTION
## Summary

- Adds `RetrieveTrace(string id)` → `GET /v2.2/files/{id}/trace`, returns `null` on 404. New model classes `ScaniiTraceResult` and `ScaniiTraceEvent` added under `Scanii/Models/`.
- Adds `ProcessFromUrl(string location, string callback = null, Dictionary<string, string> metadata = null)` → `POST /v2.2/files` with `location` multipart form field, returns `ScaniiProcessingResult` (synchronous, 201).
- Both methods are documented as v2.2 preview surface in XML doc comments.
- No new runtime dependencies.
- Version bumped to `7.1.0` in `Scanii.csproj`.

## Test plan

- [ ] `ShouldRetrieveTraceForKnownId` — processes a file, retrieves trace, asserts non-empty events with non-default timestamps and non-null messages
- [ ] `ShouldReturnNullForUnknownTraceId` — asserts null returned for unknown id (404)
- [ ] `ShouldProcessFromUrl` — submits `{endpoint}/static/eicar.txt`, hard-asserts `content.malicious.eicar-test-signature` finding
- [ ] Full existing test suite (19 passing, 1 skipped pre-existing callback stub) — verified locally against native arm64 scanii-cli binary
- [ ] `dotnet format --verify-no-changes` clean (also fixed pre-existing BOM + whitespace issues in `ScaniiResult.cs` and collection initializers)
- [ ] CI matrix: .NET 8.0 + 10.0 LTS × ubuntu/macos/windows via `setup-cli-action`

🤖 Generated with [Claude Code](https://claude.com/claude-code)