### PR TITLE
deprecate-auto-endpoint: mark ScaniiTarget.Auto as [Obsolete]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [7.2.0]
+
+* `ScaniiTarget.Auto` marked `[Obsolete]` — use an explicit regional target (`Us1`, `Eu1`, `Eu2`, `Ap1`, `Ap2`, `Ca1`) for data residency compliance. Will be removed in a future major version.
+
 ## [7.1.0]
 
 * Added `RetrieveTrace(id)` — retrieves the processing event trace for a previously scanned file (`GET /v2.2/files/{id}/trace`); returns `null` on 404. Preview surface per the v2.2 API spec.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```
-dotnet add package Scanii --version 7.1.0
+dotnet add package Scanii --version 7.2.0
 ```
 
 ## SDK Principles

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ dotnet add package Scanii --version 7.2.0
 ```csharp
 using Scanii;
 
-var client = ScaniiClients.CreateDefault("your-api-key", "your-api-secret");
+var client = ScaniiClients.CreateDefault(ScaniiTarget.Us1, "your-api-key", "your-api-secret");
 var result = await client.Process("/path/to/file.pdf");
 if (result.Findings.Count == 0)
     Console.WriteLine("Content is safe!");
@@ -49,22 +49,18 @@ All methods are on `IScaniiClient`, created via `ScaniiClients.CreateDefault`.
 ## Regional Endpoints
 
 ```csharp
-// Default (auto-routed)
-var client = ScaniiClients.CreateDefault(key, secret);
-
-// Regional
-var client = ScaniiClients.CreateDefault(key, secret, target: ScaniiTarget.Eu1);
+var client = ScaniiClients.CreateDefault(ScaniiTarget.Eu1, key, secret);
 ```
 
 | Target | Endpoint |
 |---|---|
-| `ScaniiTarget.Auto` | `https://api.scanii.com` |
 | `ScaniiTarget.Us1` | `https://api-us1.scanii.com` |
 | `ScaniiTarget.Ca1` | `https://api-ca1.scanii.com` |
 | `ScaniiTarget.Eu1` | `https://api-eu1.scanii.com` |
 | `ScaniiTarget.Eu2` | `https://api-eu2.scanii.com` |
 | `ScaniiTarget.Ap1` | `https://api-ap1.scanii.com` |
 | `ScaniiTarget.Ap2` | `https://api-ap2.scanii.com` |
+| ~~`ScaniiTarget.Auto`~~ | ~~`https://api.scanii.com`~~ — **deprecated**, does not guarantee regional data placement |
 
 ## Error Handling
 

--- a/Scanii/Scanii.csproj
+++ b/Scanii/Scanii.csproj
@@ -7,7 +7,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
 
     <!--always rev this up-->
-    <Version>7.1.0</Version>
+    <Version>7.2.0</Version>
 
     <LangVersion>8</LangVersion>
     <Company>Uva Software, LLC</Company>

--- a/Scanii/ScaniiClients.cs
+++ b/Scanii/ScaniiClients.cs
@@ -7,6 +7,7 @@ namespace Scanii
 {
   public static class ScaniiClients
   {
+#pragma warning disable CS0618 // ScaniiTarget.Auto is deprecated — intentional backward-compat default
     public static IScaniiClient CreateDefault(string key, string secret,
       HttpClient client = null, ScaniiTarget target = null)
     {
@@ -28,5 +29,6 @@ namespace Scanii
       target ??= ScaniiTarget.Auto;
       return new DefaultScaniiClient(target, authToken.ResourceId, "", client);
     }
+#pragma warning restore CS0618
   }
 }

--- a/Scanii/ScaniiTarget.cs
+++ b/Scanii/ScaniiTarget.cs
@@ -7,6 +7,17 @@ namespace Scanii
 {
   public class ScaniiTarget
   {
+    /// <summary>
+    /// Latency-routed endpoint. Routes to the nearest region automatically,
+    /// but does not guarantee which region processes your data.
+    /// </summary>
+    /// <remarks>
+    /// Deprecated: use an explicit regional target for data residency compliance —
+    /// <see cref="Us1"/>, <see cref="Eu1"/>, <see cref="Eu2"/>,
+    /// <see cref="Ap1"/>, <see cref="Ap2"/>, <see cref="Ca1"/>.
+    /// Will be removed in a future major version.
+    /// </remarks>
+    [Obsolete("Use an explicit regional target for data residency compliance: Us1, Eu1, Eu2, Ap1, Ap2, Ca1. Will be removed in a future major version.")]
     public static readonly ScaniiTarget Auto = new ScaniiTarget("https://api.scanii.com");
     public static readonly ScaniiTarget Us1 = new ScaniiTarget("https://api-us1.scanii.com");
     public static readonly ScaniiTarget Eu1 = new ScaniiTarget("https://api-eu1.scanii.com");


### PR DESCRIPTION
## Summary

- `ScaniiTarget.Auto` marked `[Obsolete]` pointing to `Us1`, `Eu1`, `Eu2`, `Ap1`, `Ap2`, `Ca1`
- `ScaniiClients.cs` suppresses `CS0618` around the internal backward-compat `??= ScaniiTarget.Auto` defaults
- `Scanii.csproj` version `7.1.0` → `7.2.0`; README install snippet updated to match

Part of [uvasoftware/sdks#1](https://github.com/uvasoftware/sdks/issues/1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)